### PR TITLE
Fix #12 - Increase rate limits for subscribing

### DIFF
--- a/news/views.py
+++ b/news/views.py
@@ -54,10 +54,10 @@ from news.utils import (
 TOKEN_RE = re.compile(r'^[0-9a-f-]{36}$', flags=re.IGNORECASE)
 IP_RATE_LIMIT_EXTERNAL = getattr(settings, 'IP_RATE_LIMIT_EXTERNAL', '40/m')
 IP_RATE_LIMIT_INTERNAL = getattr(settings, 'IP_RATE_LIMIT_INTERNAL', '400/m')
-# one submission for a specific message per phone number per 10 minutes
-PHONE_NUMBER_RATE_LIMIT = getattr(settings, 'PHONE_NUMBER_RATE_LIMIT', '1/10m')
-# one submission for a set of newsletters per email address per 10 minutes
-EMAIL_SUBSCRIBE_RATE_LIMIT = getattr(settings, 'EMAIL_SUBSCRIBE_RATE_LIMIT', '1/10m')
+# two submissions for a specific message per phone number per 20 minutes
+PHONE_NUMBER_RATE_LIMIT = getattr(settings, 'PHONE_NUMBER_RATE_LIMIT', '2/20m')
+# two submissions for a set of newsletters per email address per 20 minutes
+EMAIL_SUBSCRIBE_RATE_LIMIT = getattr(settings, 'EMAIL_SUBSCRIBE_RATE_LIMIT', '2/20m')
 sync_route = Route(api_token=settings.SYNC_KEY)
 
 


### PR DESCRIPTION
Fixes #12 - allow people to do a "quick sub -> unsub -> sub again dance" (thanks @pmac for the hilarious imagery).

I'm not sure about the phone number rate limits - did you also want those changed (as I have done) ? Or would you prefer for just the email subscription rate to be increased?

(Also, I haven't tested it, because I can't figure out how to get it running, hehe)