### PR TITLE
Fix bug 1353161: Import FxA Activity data into SFMC

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 web: bin/run-prod.sh
 worker: bin/run-worker.sh
 donateworker: bin/run-donate-worker.sh
+fxaworker: bin/run-fxa-activity-worker.sh
 clock: bin/run-clock.sh

--- a/bin/deis-cli-install.sh
+++ b/bin/deis-cli-install.sh
@@ -1,19 +1,10 @@
 #!/bin/sh
 
 # included in the repo because it's only available over http from deis.io
+# http://deis.io/deis-cli/install.sh
 
 # install current version unless overridden by first command-line argument
-cd ~/docker
-
-VERSION=${1:-1.13.2}
-
-if [[ -x ./deis ]]; then
-  if [[ "$VERSION" == $(./deis version) ]]; then
-    exit 0
-  else
-    rm ./deis
-  fi
-fi
+VERSION=${1:-1.13.3}
 
 # catch errors from here on out
 set -e
@@ -21,7 +12,7 @@ set -e
 # determine from whence to download the installer
 PLATFORM=`uname | tr '[:upper:]' '[:lower:]'`
 DEIS_INSTALLER=${DEIS_INSTALLER:-deis-cli-$VERSION-$PLATFORM-amd64.run}
-DEIS_BASE_URL=${DEIS_BASE_URL:-https://s3-us-west-2.amazonaws.com/get-deis}
+DEIS_BASE_URL=${DEIS_BASE_URL:-https://getdeis.blob.core.windows.net/get-deis}
 INSTALLER_URL=$DEIS_BASE_URL/$DEIS_INSTALLER
 
 # download the installer archive to /tmp

--- a/bin/run-fxa-activity-worker.sh
+++ b/bin/run-fxa-activity-worker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+exec python manage.py process_fxa_data --cron

--- a/news/management/commands/process_fxa_data.py
+++ b/news/management/commands/process_fxa_data.py
@@ -1,0 +1,163 @@
+from __future__ import print_function, unicode_literals
+
+from email.utils import formatdate
+
+from django.conf import settings
+from django.core.cache import cache
+from django.core.management import BaseCommand, CommandError
+
+import babis
+import boto3
+from apscheduler.schedulers.blocking import BlockingScheduler
+from django_statsd.clients import statsd
+from pathlib2 import Path
+from pytz import utc
+from raven.contrib.django.raven_compat.models import client as sentry_client
+
+from news.backends.sfmc import sfmc, NewsletterException
+
+
+TMP = Path('/tmp')
+BUCKET_DIR = 'fxa-last-active-timestamp/data'
+DATA_PATH = TMP.joinpath(BUCKET_DIR)
+FXA_IDS = {}
+FILE_DONE_KEY = 'fxa_activity:completed:%s'
+TWO_WEEKS = 60 * 60 * 24 * 14
+schedule = BlockingScheduler(timezone=utc)
+
+
+def _fxa_id_key(fxa_id):
+    return 'fxa_activity:%s' % fxa_id
+
+
+def get_fxa_time(fxa_id):
+    fxatime = FXA_IDS.get(fxa_id)
+    if fxatime is None:
+        fxatime = cache.get(_fxa_id_key(fxa_id))
+        if fxatime:
+            FXA_IDS[fxa_id] = fxatime
+
+    return fxatime or 0
+
+
+def set_fxa_time(fxa_id, fxa_time):
+    try:
+        sfmc.upsert_row(settings.FXA_SFMC_DE, {
+            'FXA_ID': fxa_id,
+            'Timestamp': formatdate(timeval=fxa_time, usegmt=True),
+        })
+    except NewsletterException:
+        sentry_client.captureException()
+        # try again later
+        return
+
+    FXA_IDS[fxa_id] = fxa_time
+    cache.set(_fxa_id_key(fxa_id), fxa_time, timeout=TWO_WEEKS)
+
+
+def file_is_done(pathobj):
+    return bool(cache.get(FILE_DONE_KEY % pathobj.name))
+
+
+def set_file_done(pathobj):
+    # cache done state for 2 weeks. files stay in s3 bucket for 1 week
+    cache.set(FILE_DONE_KEY % pathobj.name, 1, timeout=TWO_WEEKS)
+
+
+def update_fxa_data(current_timestamps):
+    """Store the updated timestamps in a local dict, the cache, and SFMC."""
+    update_count = 0
+    print('attempting to update %s fxa timestamps' % len(current_timestamps))
+    for fxaid, timestamp in current_timestamps.iteritems():
+        curr_ts = get_fxa_time(fxaid)
+        if timestamp > curr_ts:
+            update_count += 1
+            set_fxa_time(fxaid, timestamp)
+
+    print('updated %s fxa timestamps' % update_count)
+    statsd.gauge('process_fxa_data.updates', update_count)
+
+
+def download_fxa_files():
+    s3 = boto3.resource('s3',
+                        aws_access_key_id=settings.FXA_ACCESS_KEY_ID,
+                        aws_secret_access_key=settings.FXA_SECRET_ACCESS_KEY)
+    bucket = s3.Bucket(settings.FXA_S3_BUCKET)
+    for obj in bucket.objects.filter(Prefix=BUCKET_DIR):
+        print('found %s in s3 bucket' % obj.key)
+        tmp_path = TMP.joinpath(obj.key)
+        if not tmp_path.name.endswith('.csv'):
+            continue
+
+        if file_is_done(tmp_path):
+            continue
+
+        if not tmp_path.exists():
+            print('getting ' + obj.key)
+            print('size is %s' % obj.size)
+            tmp_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                bucket.download_file(obj.key, str(tmp_path))
+                print('downloaded %s' % tmp_path)
+            except Exception:
+                # something went wrong, delete file
+                print('bad things happened. deleting %s' % tmp_path)
+                tmp_path.unlink()
+
+
+def get_fxa_data():
+    all_fxa_times = {}
+    data_files = DATA_PATH.glob('*.csv')
+    for tmp_path in sorted(data_files):
+        if file_is_done(tmp_path):
+            continue
+
+        print('loading data from %s' % tmp_path)
+        # collect all of the latest timestamps from all files in a dict first
+        # to ensure that we have the minimum data set to compare against SFMC
+        with tmp_path.open() as fxafile:
+            file_count = 0
+            for line in fxafile:
+                file_count += 1
+                fxaid, timestamp = line.strip().split(',')
+                curr_ts = all_fxa_times.get(fxaid, 0)
+                timestamp = int(timestamp)
+                if timestamp > curr_ts:
+                    all_fxa_times[fxaid] = timestamp
+
+            if file_count < 1000000:
+                # if there were fewer than 1M rows we probably got a truncated file
+                # try again later (typically they contain 20M)
+                print('possibly truncated file: %s' % tmp_path)
+            else:
+                set_file_done(tmp_path)
+
+            # done with file either way
+            tmp_path.unlink()
+
+    return all_fxa_times
+
+
+@schedule.scheduled_job('cron', id='process_fxa_data', hour=1, minute=0, max_instances=1)
+@babis.decorator(ping_before=settings.FXA_SNITCH_URL, fail_silenty=True)
+def main():
+    download_fxa_files()
+    update_fxa_data(get_fxa_data())
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('--cron', action='store_true', default=False,
+                            help='Run the cron schedule instead of just once')
+
+    def handle(self, *args, **options):
+        if not all(getattr(settings, name) for name in ['FXA_ACCESS_KEY_ID',
+                                                        'FXA_SECRET_ACCESS_KEY',
+                                                        'FXA_S3_BUCKET']):
+            raise CommandError('FXA S3 Bucket access not configured')
+
+        if options['cron']:
+            print('cron schedule starting')
+            schedule.start()
+        else:
+            main()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,8 +27,6 @@ django-sslify-admin==0.5.0 \
     --hash=sha256:f4f3877e4ace8451ded7764f7f4b70459da405d73a5a72a28f0d23f50080291d
 django-statsd-mozilla==0.3.15 \
     --hash=sha256:c0e90f304bbf6f10f63e0019102980c950dc683326d2a4e50e7199decc43c36a
-pathlib==1.0.1 \
-    --hash=sha256:6940718dfc3eff4258203ad5021090933e5c04707d5ca8cc9e73c94a7894ea9f
 python-decouple==2.3 \
     --hash=sha256:b9fbf747fa8e711d330f2f436b9b2ecf5eed9eb67a637ca81abcd11c2abedec8
 pytz==2015.4 \
@@ -128,4 +126,16 @@ python-dateutil==2.6.0 \
 s3transfer==0.1.9 \
     --hash=sha256:17114f393101a6c4a49318429b9facede6183ec52fd14ca54e09aa496da56fbc \
     --hash=sha256:17ad7d672115f93a72ed7917209cb0bb02fc87f96f11886408ed8a6b1bb4c754
-
+pathlib2==2.2.1 \
+    --hash=sha256:31b7bac38144612b18fb55adc4285e34a766ae64fdb1200c72e0b0cdd632ef4b \
+    --hash=sha256:ce9007df617ef6b7bd8a31cd2089ed0c1fed1f7c23cf2bf1ba140b3dd563175d
+scandir==1.5 \
+    --hash=sha256:c2612d1a487d80fb4701b4a91ca1b8f8a695b1ae820570815e85e8c8b23f1283
+APScheduler==3.3.1 \
+    --hash=sha256:bc9f96e498adb362beb5f1d3715a2570d100183add4ace5227c1a7d5dbaac900 \
+    --hash=sha256:f68874dff1bdffcc6ce3adb7840c1e4d162c609a3e3f831351df30b75732767b
+tzlocal==1.3.2 \
+    --hash=sha256:07dee68c9f5b9ca665762eb0860418cc289bd561f7e32a4ec37a09426895e7bd
+babis==0.1.0 \
+    --hash=sha256:72164b5371c3a83dbd91dcc68876639dc11b1e9ead97a1601a768c3d996a5707 \
+    --hash=sha256:788789bada547d170674981de1cf4a7b674af695ed51b255ef99c71aa4ba2ac4

--- a/settings.py
+++ b/settings.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 import dj_database_url
 import django_cache_url
 from decouple import config, Csv, UndefinedValueError
-from pathlib import Path
+from pathlib2 import Path
 
 # Application version.
 VERSION = (0, 1)
@@ -316,6 +316,12 @@ DONATE_QUEUE_WAIT_TIME = config('DONATE_QUEUE_WAIT_TIME', cast=int, default=10)
 DONATE_OPP_RECORD_TYPE = config('DONATE_OPP_RECORD_TYPE', default='')
 DONATE_CONTACT_RECORD_TYPE = config('DONATE_CONTACT_RECORD_TYPE', default='')
 DONATE_SNITCH_ID = config('DONATE_SNITCH_ID', default='')
+
+FXA_ACCESS_KEY_ID = config('FXA_ACCESS_KEY_ID', default='')
+FXA_SECRET_ACCESS_KEY = config('FXA_SECRET_ACCESS_KEY', default='')
+FXA_S3_BUCKET = config('FXA_S3_BUCKET', default='')
+FXA_SFMC_DE = config('FXA_SFMC_DE', default='FXA_Logins')
+FXA_SNITCH_URL = config('FXA_SNITCH_URL', default='')
 
 if sys.argv[0].endswith('py.test') or (len(sys.argv) > 1 and sys.argv[1] == 'test'):
     # stuff that's absolutely required for a test run


### PR DESCRIPTION
* Download csv files from s3
* Parse csv files and get the most recent timestamps per fxa_id
* Update said timestamps in a Data Extension in SFMC
* Cache the timestamps in Redis to avoid so many SFMC API calls

These files are FxA login timestamps per day. Each one contains around 20M rows. After processing all 8 (max in the bucket at a time) there are around 10M records to update. This will take quite a while per run.