### PR TITLE
Re #24: Remove secure checks from code and add HTTPS redirectors to support Deis v1 and v2

### DIFF
--- a/news/middleware.py
+++ b/news/middleware.py
@@ -11,14 +11,11 @@ class GraphiteViewHitCountMiddleware(GraphiteRequestTimingMiddleware):
         super(GraphiteViewHitCountMiddleware, self).process_view(
             request, view_func, view_args, view_kwargs)
         if hasattr(request, '_view_name'):
-            secure = 'secure' if request.is_secure() else 'insecure'
-            data = dict(module=request._view_module, name=request._view_name,
-                        method=request.method, secure=secure)
-            statsd.incr('view.count.{module}.{name}.{method}.{secure}'.format(**data))
+            data = dict(module=request._view_module,
+                        name=request._view_name,
+                        method=request.method)
             statsd.incr('view.count.{module}.{name}.{method}'.format(**data))
-            statsd.incr('view.count.{module}.{method}.{secure}'.format(**data))
             statsd.incr('view.count.{module}.{method}'.format(**data))
-            statsd.incr('view.count.{method}.{secure}'.format(**data))
             statsd.incr('view.count.{method}'.format(**data))
 
 

--- a/news/tests/test_update_user_task.py
+++ b/news/tests/test_update_user_task.py
@@ -166,20 +166,6 @@ class UpdateUserTaskTests(TestCase):
 
     @patch('news.views.newsletter_and_group_slugs')
     @patch('news.views.newsletter_private_slugs')
-    def test_subscribe_private_newsletter_ssl_required(self, mock_private, mock_slugs):
-        """
-        If subscribing to a private newsletter and the request isn't HTTPS, return a 401.
-        """
-        mock_private.return_value = ['private']
-        mock_slugs.return_value = ['private', 'other']
-        data = {'newsletters': 'private', 'email': 'dude@example.com'}
-        request = self.factory.post('/', data)
-        request.is_secure = lambda: False
-        response = update_user_task(request, SUBSCRIBE, data)
-        self.assert_response_error(response, 401, errors.BASKET_SSL_REQUIRED)
-
-    @patch('news.views.newsletter_and_group_slugs')
-    @patch('news.views.newsletter_private_slugs')
     @patch('news.views.has_valid_api_key')
     def test_subscribe_private_newsletter_invalid_api_key(self, mock_api_key, mock_private, mock_slugs):
         """
@@ -190,26 +176,11 @@ class UpdateUserTaskTests(TestCase):
         mock_slugs.return_value = ['private', 'other']
         data = {'newsletters': 'private', 'email': 'dude@example.com'}
         request = self.factory.post('/', data)
-        request.is_secure = lambda: True
         mock_api_key.return_value = False
 
         response = update_user_task(request, SUBSCRIBE, data)
         self.assert_response_error(response, 401, errors.BASKET_AUTH_ERROR)
         mock_api_key.assert_called_with(request)
-
-    @patch('news.views.newsletter_slugs')
-    @patch('news.views.newsletter_private_slugs')
-    def test_set_private_newsletter_ssl_required(self, mock_private, mock_slugs):
-        """
-        If subscribing to a private newsletter and the request isn't HTTPS, return a 401.
-        """
-        mock_private.return_value = ['private']
-        mock_slugs.return_value = ['private', 'other']
-        data = {'newsletters': 'private', 'email': 'dude@example.com'}
-        request = self.factory.post('/', data)
-        request.is_secure = lambda: False
-        response = update_user_task(request, SET, data)
-        self.assert_response_error(response, 401, errors.BASKET_SSL_REQUIRED)
 
     @patch('news.views.newsletter_slugs')
     @patch('news.views.newsletter_private_slugs')
@@ -223,7 +194,6 @@ class UpdateUserTaskTests(TestCase):
         mock_slugs.return_value = ['private', 'other']
         data = {'newsletters': 'private', 'email': 'dude@example.com'}
         request = self.factory.post('/', data)
-        request.is_secure = lambda: True
         mock_api_key.return_value = False
 
         response = update_user_task(request, SET, data)
@@ -245,7 +215,6 @@ class UpdateUserTaskTests(TestCase):
         mock_group_slugs.return_value = ['private', 'other']
         data = {'newsletters': 'private', 'email': 'dude@example.com'}
         request = self.factory.post('/', data)
-        request.is_secure = lambda: True
         mock_api_key.return_value = True
 
         response = update_user_task(request, SUBSCRIBE, data)

--- a/news/tests/test_users.py
+++ b/news/tests/test_users.py
@@ -77,14 +77,13 @@ class TestLookupUser(TestCase):
         self.user_data = {'status': 'ok'}
         self.url = reverse('lookup_user')
 
-    def ssl_get(self, params=None, **extra):
-        extra['wsgi.url_scheme'] = 'https'
+    def get(self, params=None, **extra):
         params = params or {}
         return self.client.get(self.url, data=params, **extra)
 
     def test_no_parms(self):
         """Passing no parms is a 400 error"""
-        rsp = self.ssl_get()
+        rsp = self.get()
         self.assertEqual(400, rsp.status_code, rsp.content)
 
     def test_both_parms(self):
@@ -93,13 +92,8 @@ class TestLookupUser(TestCase):
             'token': 'dummy',
             'email': 'dummy@example.com',
         }
-        rsp = self.ssl_get(params=params)
+        rsp = self.get(params=params)
         self.assertEqual(400, rsp.status_code, rsp.content)
-
-    def test_not_ssl(self):
-        """Without SSL, immediate 401"""
-        rsp = self.client.get(self.url)
-        self.assertEqual(401, rsp.status_code, rsp.content)
 
     @patch('news.views.get_user_data')
     def test_with_token(self, get_user_data):
@@ -108,7 +102,7 @@ class TestLookupUser(TestCase):
         params = {
             'token': 'dummy',
         }
-        rsp = self.ssl_get(params=params)
+        rsp = self.get(params=params)
         self.assertEqual(200, rsp.status_code, rsp.content)
         self.assertEqual(self.user_data, json.loads(rsp.content))
 
@@ -117,7 +111,7 @@ class TestLookupUser(TestCase):
         params = {
             'email': 'mail@example.com',
         }
-        rsp = self.ssl_get(params)
+        rsp = self.get(params)
         self.assertEqual(401, rsp.status_code, rsp.content)
 
     def test_with_email_disabled_auth(self):
@@ -128,7 +122,7 @@ class TestLookupUser(TestCase):
             'email': 'mail@example.com',
             'api-key': self.auth.api_key,
         }
-        rsp = self.ssl_get(params)
+        rsp = self.get(params)
         self.assertEqual(401, rsp.status_code, rsp.content)
 
     def test_with_email_bad_auth(self):
@@ -137,7 +131,7 @@ class TestLookupUser(TestCase):
             'email': 'mail@example.com',
             'api-key': 'BAD KEY',
         }
-        rsp = self.ssl_get(params)
+        rsp = self.get(params)
         self.assertEqual(401, rsp.status_code, rsp.content)
 
     @patch('news.views.get_user_data')
@@ -148,7 +142,7 @@ class TestLookupUser(TestCase):
             'api-key': self.auth.api_key,
         }
         get_user_data.return_value = self.user_data
-        rsp = self.ssl_get(params)
+        rsp = self.get(params)
         self.assertEqual(200, rsp.status_code, rsp.content)
         self.assertEqual(self.user_data, json.loads(rsp.content))
 
@@ -159,7 +153,7 @@ class TestLookupUser(TestCase):
             'email': 'mail@example.com',
         }
         get_user_data.return_value = self.user_data
-        rsp = self.ssl_get(params, HTTP_X_API_KEY=self.auth.api_key)
+        rsp = self.get(params, HTTP_X_API_KEY=self.auth.api_key)
         self.assertEqual(200, rsp.status_code, rsp.content)
         self.assertEqual(self.user_data, json.loads(rsp.content))
 
@@ -171,5 +165,5 @@ class TestLookupUser(TestCase):
             'email': 'mail@example.com',
             'api-key': self.auth.api_key,
         }
-        rsp = self.ssl_get(params)
+        rsp = self.get(params)
         self.assertEqual(404, rsp.status_code, rsp.content)

--- a/news/views.py
+++ b/news/views.py
@@ -130,12 +130,6 @@ def confirm(request, token):
 @require_POST
 @csrf_exempt
 def fxa_activity(request):
-    if not request.is_secure():
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'fxa-activity requires SSL',
-            'code': errors.BASKET_SSL_REQUIRED,
-        }, 401)
     if not has_valid_api_key(request):
         return HttpResponseJSON({
             'status': 'error',
@@ -164,12 +158,6 @@ def fxa_activity(request):
 @require_POST
 @csrf_exempt
 def fxa_register(request):
-    if not request.is_secure():
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'fxa-register requires SSL',
-            'code': errors.BASKET_SSL_REQUIRED,
-        }, 401)
     if not has_valid_api_key(request):
         return HttpResponseJSON({
             'status': 'error',
@@ -329,18 +317,12 @@ def subscribe(request):
     optin = data.pop('optin', 'N').upper() == 'Y'
     sync = data.pop('sync', 'N').upper() == 'Y'
 
-    if optin and (not request.is_secure() or not has_valid_api_key(request)):
+    if optin and not has_valid_api_key(request):
         # for backward compat we just ignore the optin if
         # no valid API key is sent.
         optin = False
 
     if sync:
-        if not request.is_secure():
-            return HttpResponseJSON({
-                'status': 'error',
-                'desc': 'subscribe with sync=Y requires SSL',
-                'code': errors.BASKET_SSL_REQUIRED,
-            }, 401)
         if not has_valid_api_key(request):
             return HttpResponseJSON({
                 'status': 'error',
@@ -580,13 +562,6 @@ def lookup_user(request):
             'code': errors.BASKET_NETWORK_FAILURE,
         }, 400)
 
-    if not request.is_secure():
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'lookup_user always requires SSL',
-            'code': errors.BASKET_SSL_REQUIRED,
-        }, 401)
-
     token = request.GET.get('token', None)
     email = request.GET.get('email', None)
 
@@ -665,13 +640,6 @@ def update_user_task(request, api_call_type, data=None, optin=False, sync=False)
                 }, 400)
 
             if api_call_type != UNSUBSCRIBE and nl in private_newsletters:
-                if not request.is_secure():
-                    return HttpResponseJSON({
-                        'status': 'error',
-                        'desc': 'private newsletter subscription requires SSL',
-                        'code': errors.BASKET_SSL_REQUIRED,
-                    }, 401)
-
                 if not has_valid_api_key(request):
                     return HttpResponseJSON({
                         'status': 'error',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,8 +23,6 @@ django-picklefield==0.3.1 \
 django-ratelimit==0.6.0 \
     --hash=sha256:f73b53b2c4fd342cbd4b983ffc33fdcf8f8a6f595d548865ea63c839ef38293c \
     --hash=sha256:93dabcd3131a88d6fd19ff4de0a8351ed44b4ec943e8d58d27306f7faf8821af
-django-sslify-admin==0.5.0 \
-    --hash=sha256:f4f3877e4ace8451ded7764f7f4b70459da405d73a5a72a28f0d23f50080291d
 django-statsd-mozilla==0.3.15 \
     --hash=sha256:c0e90f304bbf6f10f63e0019102980c950dc683326d2a4e50e7199decc43c36a
 python-decouple==2.3 \

--- a/settings.py
+++ b/settings.py
@@ -133,6 +133,7 @@ TEMPLATES = [
 ]
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.security.SecurityMiddleware',
     'news.middleware.HostnameMiddleware',
     'django.middleware.common.CommonMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -145,9 +146,6 @@ MIDDLEWARE_CLASSES = (
     'django_statsd.middleware.GraphiteMiddleware',
     'ratelimit.middleware.RatelimitMiddleware',
 )
-
-if not DISABLE_ADMIN:
-    MIDDLEWARE_CLASSES = ('sslifyadmin.middleware.SSLifyAdminMiddleware',) + MIDDLEWARE_CLASSES
 
 ROOT_URLCONF = 'urls'
 
@@ -169,8 +167,13 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 )
 
-SSLIFY_ADMIN_DISABLE = config('SSLIFY_ADMIN_DISABLE', DEBUG, cast=bool)
-if not SSLIFY_ADMIN_DISABLE:
+# SecurityMiddleware settings
+SECURE_HSTS_SECONDS = config('SECURE_HSTS_SECONDS', default='0', cast=int)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+SECURE_BROWSER_XSS_FILTER = config('SECURE_BROWSER_XSS_FILTER', default=True, cast=bool)
+SECURE_CONTENT_TYPE_NOSNIFF = config('SECURE_CONTENT_TYPE_NOSNIFF', default=True, cast=bool)
+SECURE_SSL_REDIRECT = config('SECURE_SSL_REDIRECT', default=False, cast=bool)
+if config('USE_SECURE_PROXY_HEADER', default=SECURE_SSL_REDIRECT, cast=bool):
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 RAVEN_CONFIG = {

--- a/wsgi/app.py
+++ b/wsgi/app.py
@@ -2,6 +2,7 @@ import os
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
+from django.core.handlers.wsgi import WSGIRequest
 from django.core.wsgi import get_wsgi_application
 
 from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
@@ -20,7 +21,19 @@ if newrelic:
     else:
         newrelic = False
 
+IS_HTTPS = os.environ.get('HTTPS', '').strip() == 'on'
+
+
+class WSGIHTTPSRequest(WSGIRequest):
+    def _get_scheme(self):
+        if IS_HTTPS:
+            return 'https'
+
+        return super(WSGIHTTPSRequest, self)._get_scheme()
+
+
 application = get_wsgi_application()
+application.request_class = WSGIHTTPSRequest
 application = DjangoWhiteNoise(application)
 application = Sentry(application)
 


### PR DESCRIPTION
This mimics the setup in Bedrock. We'll just need to update the configs for basket in the various Deis clusters.